### PR TITLE
soc/msm8939: add status for msm8939

### DIFF
--- a/_soc/msm8939.md
+++ b/_soc/msm8939.md
@@ -1,0 +1,66 @@
+---
+name: MSM8939
+layout: soc
+status-audio-lpascodecs: 4.10
+status-audio-lpasslpi: 4.6
+status-camera: WIP
+status-camera-csi: 
+status-camera-i2c:
+status-camera-vfe:
+status-clock-gcc: 5.12
+status-clock-rpmhcc: 5.11
+status-clock-tcsrcc: N/A
+status-connectivity-bluetooth: 4.10
+status-connectivity-ethernet: N/A
+status-connectivity-ipa: N/A
+status-connectivity-wlan: 4.11
+status-cpu-cpufreq: WIP
+status-cpu-cpuidle: N
+status-cpu-l3cache: 4.6
+status-cpu-smp: WIP
+status-cpu-smp-comment: Using <a href=https://github.com/msm8916-mainline/lk2nd/releases/tag/0.14.0>lk2nd</a> as a bootloader is required to enable SMP
+status-crypto-rng: 4.4
+status-debug-coresight: 4.11
+status-display-dp: N/A
+status-display-dsi: 4.9
+status-display-hdmi: N/A 
+status-display-hdmiaudio: N/A
+status-display-hdmicec: N/A
+status-display-gpu: 4.14
+status-display-lvds: N/A
+status-dma-bam: 4.3
+status-i2c: 4.3
+status-interconnects: 5.12
+status-pcie: N/A
+status-pinctrl: 5.9
+status-powerthermal-spm: 5.16
+status-powerthermal-tsens: 4.9
+status-psci-comment: msm8939 is a non-PSCI compliant platform so we can't support SMP without additional downstream patches
+status-qfprom: 4.9
+status-remoteproc: 4.10
+status-remoteproc-cdsp: N/A
+status-remoteproc-fastrpc: 5.7
+status-remoteproc-mdsp: 4.10
+status-remoteproc-sdsp: N/A
+status-smmu: 4.14
+status-spi: 4.3
+status-spmi: 4.2
+status-sram-rpmh-stats: 5.17
+status-storage-nand: N/A
+status-storage-sata: N/A
+status-storage-sdcc: 4.3
+status-storage-ufs: N/A
+status-storage-ufsice: N/A
+status-uart: 4.1
+status-usb: 4.3
+status-usb-hostmode: 4.3
+status-usb-periphmode: 4.3
+status-usb-typec: N/A
+status-usb-usb4: N/A
+status-usb-usbotg: 4.3
+status-video-venus: WIP
+pmic: pm8916
+---
+Snapdragon 615 (Shere)
+
+Tested Boards: Sony Xperia M4 Aqua


### PR DESCRIPTION
msm8939 takes and reuses alot of the msm8916 code already upstream, however there are some cases where the SoC deviates.

- GCC
- Camera and Venus still need work
- RPM
- Pinctrl
- Interconnects

Also given msm8939 is not PSCI we should mark CPU idle as a no and CPU freq as WIP, contingent on CPR work for msm8939.