### PR TITLE
soc/sdx65: add status for SDX65

### DIFF
--- a/_pmic/pm8150b.md
+++ b/_pmic/pm8150b.md
@@ -30,3 +30,4 @@ pmic-usb-typecpd: WIP
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
+This PMIC is usually used with the [SM8150](../soc/sm8150), [SM8250](../soc/sm8250) and [SDX65](../soc/sdx65) platforms.

--- a/_pmic/pmk8350.md
+++ b/_pmic/pmk8350.md
@@ -30,4 +30,4 @@ pmic-usb-typecpd: N/A
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SM8450](../soc/sm8450), [SM8350](../soc/sm8350), sc7280, sm6375 & sm7225 platforms.
+This PMIC is usually used with the [SM8450](../soc/sm8450), [SM8350](../soc/sm8350), [SDX65](../soc/sdx65), sc7280, sm6375 & sm7225 platforms.

--- a/_soc/sdx65.md
+++ b/_soc/sdx65.md
@@ -1,0 +1,96 @@
+---
+name: SDX65
+layout: soc
+status-audio-adspaudio: N/A
+status-audio-adspelite: N/A
+status-audio-analogcodec: N/A
+status-audio-dmic: N/A
+status-audio-headset: N/A
+status-audio-i2s: N/A
+status-audio-lpascodecs: N/A
+status-audio-lpasslpi: N/A
+status-audio-slimbus: N/A
+status-audio-soundwire: N/A
+status-audio-spdif: N/A
+status-camera: N/A
+status-camera-csi: N/A
+status-camera-datapath: N/A
+status-camera-eva: N/A
+status-camera-i2c: N/A
+status-camera-sfe: N/A
+status-camera-vfe: N/A
+status-camera-vfelight: N/A
+status-clock-gcc: 5.17
+status-clock-rpmhcc: 5.17
+status-clock-tcsrcc: N/A
+status-connectivity-bluetooth: N/A
+status-connectivity-ethernet: N/A
+status-connectivity-ipa: 6.4
+status-connectivity-wlan: N/A
+status-cpu-bwmon: WIP
+status-cpu-cachetop:
+status-cpu-cpufreq: 6.0
+status-cpu-cpuidle:
+status-cpu-ddrfreq:
+status-cpu-l3cache:
+status-cpu-llcc:
+status-cpu-smp: N/A
+status-crypto-qcrypto: N/A
+status-crypto-rng: N/A
+status-debug-coresight: N/A
+status-debug-dcc: N/A
+status-debug-eud: WIP
+status-display-dp: N/A
+status-display-dsi: N/A
+status-display-hdmi: N/A
+status-display-hdmiaudio: N/A
+status-display-hdmicec: N/A
+status-display-kgsl: N/A
+status-display-lvds: N/A
+status-dma-bam: 6.0
+status-dma-gpi: N/A
+status-gnss: N/A
+status-hwspinlocks: 5.19
+status-i2c: N/A
+status-interconnects: 5.19
+status-pcie: 6.4
+status-pinctrl: 5.17
+status-powerthermal-currentlimit:
+status-powerthermal-lmh:
+status-powerthermal-mpm:
+status-powerthermal-pdc: 5.17
+status-powerthermal-spm:
+status-powerthermal-tsens:
+status-qfprom:
+status-remoteproc: 6.0
+status-remoteproc-adsp: N/A
+status-remoteproc-cdsp: N/A
+status-remoteproc-fastrpc: N/A
+status-remoteproc-mdsp: 6.0
+status-remoteproc-sdsp: N/A
+status-smmu: 5.19
+status-spi: N/A
+status-spmi: 5.19
+status-sram-imem: 6.0
+status-sram-rpmh-stats:
+status-storage-emmcice: N/A
+status-storage-nand: 6.0
+status-storage-sata: N/A
+status-storage-sdcc: 5.19
+status-storage-ufs: N/A
+status-storage-ufsice: N/A
+status-uart: 5.17
+status-usb: 6.0
+status-usb-hostmode:
+status-usb-periphmode: 6.0
+status-usb-typec: WIP
+status-usb-usb4:
+status-usb-usbotg:
+status-video-venus: N/A
+status-watchdog: 6.0
+pmic: pmk8350, pm8150b, pmx65
+---
+SDX65 (Olympic)
+
+Tested Boards:
+- SDX65-MTP


### PR DESCRIPTION
SDX65 is one of the Qualcomm platforms supported by upstream. Describe its status.
Also add the SDX65 entries in the corresponding PMICs present.