### PR TITLE
sass/status: introduce zebra color coding

### DIFF
--- a/_sass/status.scss
+++ b/_sass/status.scss
@@ -1,18 +1,35 @@
-td.status-Y {
-	background-color: green;
-}
-td.status-no-dts {
-	background-color: lightgreen;
-}
-td.status-N {
-	background-color: red;
-}
-td.status-NA {
-	background-color: gray;
-}
-td.status-next {
-	background-color: yellow;
-}
-td.status-unknown {
-	background-color: lightgray;
+tr {
+	&:nth-child(even) {
+		td.status-Y {
+			background-color: rgb(0,160,0);
+		}
+		td.status-N {
+			background-color: lightcoral;
+		}
+		td.status-NA {
+			background-color: darkgray;
+		}
+		td.status-unknown {
+			background-color: lightgray;
+		}
+	}
+
+	td.status-Y {
+		background-color: green;
+	}
+	td.status-no-dts {
+		background-color: lightgreen;
+	}
+	td.status-N {
+		background-color: red;
+	}
+	td.status-NA {
+		background-color: gray;
+	}
+	td.status-next {
+		background-color: yellow;
+	}
+	td.status-unknown {
+		background-color: silver;
+	}
 }


### PR DESCRIPTION
Introduce zebra color coding for status fields to ease reading the table. It makes it easier to follow the lines in the table.