### PR TITLE
pmic: Fix `fuelgague` -> `fuelgauge` typo

### DIFF
--- a/_pmic/pm8005.md
+++ b/_pmic/pm8005.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 4.19
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8009.md
+++ b/_pmic/pm8009.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.9
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8010.md
+++ b/_pmic/pm8010.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: N/A
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8150.md
+++ b/_pmic/pm8150.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.4
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8150b.md
+++ b/_pmic/pm8150b.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N
+pmic-fuelgauge: N
 pmic-gpio: 5.4
 pmic-haptics: N
 pmic-keypad: N/A

--- a/_pmic/pm8150l.md
+++ b/_pmic/pm8150l.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: 6.4
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.4
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8350.md
+++ b/_pmic/pm8350.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.19
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8350b.md
+++ b/_pmic/pm8350b.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.19
 pmic-haptics: N
 pmic-keypad: N/A

--- a/_pmic/pm8350c.md
+++ b/_pmic/pm8350c.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.13
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8450.md
+++ b/_pmic/pm8450.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.18
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8550.md
+++ b/_pmic/pm8550.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: 6.5
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 6.3
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8550b.md
+++ b/_pmic/pm8550b.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: 6.3
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 6.3
 pmic-haptics: N
 pmic-keypad: N/A

--- a/_pmic/pm8550ve.md
+++ b/_pmic/pm8550ve.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 6.3
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8550vs.md
+++ b/_pmic/pm8550vs.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 6.3
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8821.md
+++ b/_pmic/pm8821.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: N/A
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8916.md
+++ b/_pmic/pm8916.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 4.2
 pmic-haptics: 5.6
 pmic-keypad: N/A

--- a/_pmic/pm8921.md
+++ b/_pmic/pm8921.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N
+pmic-fuelgauge: N
 pmic-gpio: 4.3
 pmic-haptics: N/A
 pmic-keypad: 3.0

--- a/_pmic/pm8994.md
+++ b/_pmic/pm8994.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 4.6
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pm8998.md
+++ b/_pmic/pm8998.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: 4.20
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 4.19
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pmc8380.md
+++ b/_pmic/pmc8380.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: WIP
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pmi8994.md
+++ b/_pmic/pmi8994.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N
-pmic-fuelgague: N
+pmic-fuelgauge: N
 pmic-gpio: 4.14
 pmic-haptics: N
 pmic-keypad: N/A

--- a/_pmic/pmi8998.md
+++ b/_pmic/pmi8998.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: 6.5
-pmic-fuelgague: 6.5
+pmic-fuelgauge: 6.5
 pmic-gpio: 4.20
 pmic-haptics: N
 pmic-keypad: N/A

--- a/_pmic/pmk8350.md
+++ b/_pmic/pmk8350.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.13
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pmk8550.md
+++ b/_pmic/pmk8550.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 6.3
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pmm8654au.md
+++ b/_pmic/pmm8654au.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 6.4
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pmr735a.md
+++ b/_pmic/pmr735a.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.13
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pmr735b.md
+++ b/_pmic/pmr735b.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 5.19
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/pmr735d.md
+++ b/_pmic/pmr735d.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: 6.3
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/_pmic/smb2360.md
+++ b/_pmic/smb2360.md
@@ -13,7 +13,7 @@ pmic-clkdiv: N/A
 pmic-coincell: N/A
 pmic-eusb2repeat: N
 pmic-flash: N/A
-pmic-fuelgague: N/A
+pmic-fuelgauge: N/A
 pmic-gpio: WIP
 pmic-haptics: N/A
 pmic-keypad: N/A

--- a/pmic.yaml
+++ b/pmic.yaml
@@ -63,8 +63,8 @@ usb:
 coincell:
   name: Coincell
   intop: True
-fuelgague:
-  name: Fuelgague/Charging
+fuelgauge:
+  name: Fuelgauge/Charging
   intop: True
 haptics:
   name: Haptics


### PR DESCRIPTION
Typo found by @sraase!
