### PR TITLE
soc: remove internal SoC naming

### DIFF
--- a/_soc/msm8916.md
+++ b/_soc/msm8916.md
@@ -59,6 +59,6 @@ status-usb-usbotg: 4.3
 status-video-venus: 4.14
 pmic: pm8916
 ---
-Snapdragon 410 (Bagheera)
+Snapdragon 410 
 
 Tested Boards: Dragonboard 410c

--- a/_soc/msm8939.md
+++ b/_soc/msm8939.md
@@ -61,6 +61,6 @@ status-usb-usbotg: 4.3
 status-video-venus: WIP
 pmic: pm8916
 ---
-Snapdragon 615 (Shere)
+Snapdragon 615 
 
 Tested Boards: Sony Xperia M4 Aqua

--- a/_soc/sc8280xp.md
+++ b/_soc/sc8280xp.md
@@ -57,6 +57,6 @@ status-usb-typec: 6.0
 status-watchdog: 6.0
 pmic: pmk8280, pmc8280, pmc8280c, pmr735a
 ---
-Snapdragon 8cx Gen 3 (Makena)
+Snapdragon 8cx Gen 3
 
 Tested Boards: Lenovo X13s, SA8540P Snapdragon Ride (Qdrive-3), Qualcomm SA8295P ADP

--- a/_soc/sdm845.md
+++ b/_soc/sdm845.md
@@ -64,6 +64,6 @@ status-video-venus: 5.4
 status-watchdog: 5.5
 pmic: pm8998, pmi8998, pm8005
 ---
-Snapdragon 845 (Napali)
+Snapdragon 845
 
 

--- a/_soc/sdx65.md
+++ b/_soc/sdx65.md
@@ -90,7 +90,7 @@ status-video-venus: N/A
 status-watchdog: 6.0
 pmic: pmk8350, pm8150b, pmx65
 ---
-SDX65 (Olympic)
+SDX65 
 
 Tested Boards:
 - SDX65-MTP

--- a/_soc/sm8150.md
+++ b/_soc/sm8150.md
@@ -49,6 +49,6 @@ status-usb-usb4: N/A
 status-watchdog: 5.6
 pmic: pm8150, pm8150b, pm8150l, pm8009
 ---
-Snapdragon 855 (Hana)
+Snapdragon 855
 
 

--- a/_soc/sm8250.md
+++ b/_soc/sm8250.md
@@ -60,6 +60,6 @@ status-video-venus: 5.13
 status-watchdog: 5.9
 pmic: pm8150, pm8150b, pm8150l, pm8009
 ---
-Snapdragon 865 (Kona)
+Snapdragon 865
 
 Tested Boards: Qualcomm / Thundercomm RB5

--- a/_soc/sm8350.md
+++ b/_soc/sm8350.md
@@ -45,6 +45,6 @@ status-usb-periphmode: 5.13
 status-usb-usb4: N/A
 pmic: pm8350, pm8350b, pm8350c, pmk8350, pmr735a, pmr735b
 ---
-Snapdragon 888 (Lahaina)
+Snapdragon 888
 
 Tested Boards: HDK888 aka SM8350-HDK

--- a/_soc/sm8450.md
+++ b/_soc/sm8450.md
@@ -92,7 +92,7 @@ status-video-venus: N
 status-watchdog: N
 pmic: pm8350, pm8350b, pm8350c, pm8450, pmk8350, pmr735a, pmr735b
 ---
-Snapdragon 8 Gen 1 (Waipio)
+Snapdragon 8 Gen 1
 
 Tested Boards:
 - SM8450-HDK

--- a/_soc/sm8550.md
+++ b/_soc/sm8550.md
@@ -94,7 +94,7 @@ status-video-venus: N
 status-watchdog: WIP
 pmic: pm8550, pm8550b, pm8550ve, pm8550vs, pmk8550, pmr735d, pm8010
 ---
-Snapdragon 8 Gen 2 (Kailua)
+Snapdragon 8 Gen 2
 
 Tested Boards:
 - SM8550-MTP


### PR DESCRIPTION
Qualcomm internal SoC naming is not for public use, remove them.