### PR TITLE
Add entries for SM4450-QRD and related PMICs

### DIFF
--- a/_pmic/pm3001a.md
+++ b/_pmic/pm3001a.md
@@ -1,0 +1,33 @@
+---
+name: PM3001A
+layout: pmic
+pmic-adc-gpadc: N/A
+pmic-adc-iadc: N/A
+pmic-adc-rradc: N/A
+pmic-adc-thermal: N/A
+pmic-adc-touch: N/A
+pmic-adc-vadc: N/A
+pmic-audiocodec: N/A
+pmic-bms: N/A
+pmic-clkdiv: N/A
+pmic-coincell: N/A
+pmic-eusb2repeat: N/A
+pmic-flash: N/A
+pmic-fuelgauge: N/A
+pmic-gpio: N/A
+pmic-haptics: N/A
+pmic-keypad: N/A
+pmic-labib: N/A
+pmic-lpg: N/A
+pmic-mpp: N/A
+pmic-pon: N/A
+pmic-qnovo: N/A
+pmic-regulators:
+pmic-resin: N/A
+pmic-rtc: N/A
+pmic-tempalarm: N/A
+pmic-usb-extcon: N/A
+pmic-usb-typecpd: N/A
+pmic-watchdog: N/A
+pmic-wled: N/A
+---

--- a/_pmic/pm4450.md
+++ b/_pmic/pm4450.md
@@ -1,0 +1,34 @@
+---
+name: PM4450
+layout: pmic
+pmic-adc-gpadc: N/A
+pmic-adc-iadc: N/A
+pmic-adc-rradc: N/A
+pmic-adc-thermal: N/A
+pmic-adc-touch: N/A
+pmic-adc-vadc: N/A
+pmic-audiocodec: N/A
+pmic-bms: N/A
+pmic-clkdiv: N/A
+pmic-coincell: N/A
+pmic-eusb2repeat: N/A
+pmic-flash: N/A
+pmic-fuelgauge: N/A
+pmic-gpio:
+pmic-haptics: N/A
+pmic-keypad: N/A
+pmic-labib: N/A
+pmic-lpg: N/A
+pmic-mpp: N/A
+pmic-pon: N/A
+pmic-qnovo: N/A
+pmic-regulators:
+pmic-resin: N/A
+pmic-rtc: N/A
+pmic-tempalarm:
+pmic-usb-extcon: N/A
+pmic-usb-typecpd: N/A
+pmic-watchdog: N/A
+pmic-wled:
+---
+This PMIC is usually used with the [SM4450](../soc/sm4450) platform.

--- a/_pmic/pm4450c.md
+++ b/_pmic/pm4450c.md
@@ -1,0 +1,34 @@
+---
+name: PM4450C
+layout: pmic
+pmic-adc-gpadc: N/A
+pmic-adc-iadc: N/A
+pmic-adc-rradc: N/A
+pmic-adc-thermal: N/A
+pmic-adc-touch: N/A
+pmic-adc-vadc: N/A
+pmic-audiocodec: N/A
+pmic-bms: N/A
+pmic-clkdiv: N/A
+pmic-coincell: N/A
+pmic-eusb2repeat: N/A
+pmic-flash: N/A
+pmic-fuelgauge: N/A
+pmic-gpio:
+pmic-haptics: N/A
+pmic-keypad: N/A
+pmic-labib: N/A
+pmic-lpg: N/A
+pmic-mpp: N/A
+pmic-pon: N/A
+pmic-qnovo: N/A
+pmic-regulators:
+pmic-resin: N/A
+pmic-rtc: N/A
+pmic-tempalarm:
+pmic-usb-extcon: N/A
+pmic-usb-typecpd: N/A
+pmic-watchdog: N/A
+pmic-wled: N/A
+---
+This PMIC is usually used with the [SM4450](../soc/sm4450) platform.

--- a/_pmic/pmg1110.md
+++ b/_pmic/pmg1110.md
@@ -1,0 +1,33 @@
+---
+name: PMG1110
+layout: pmic
+pmic-adc-gpadc: N/A
+pmic-adc-iadc: N/A
+pmic-adc-rradc: N/A
+pmic-adc-thermal: N/A
+pmic-adc-touch: N/A
+pmic-adc-vadc: N/A
+pmic-audiocodec: N/A
+pmic-bms: N/A
+pmic-clkdiv: N/A
+pmic-coincell: N/A
+pmic-eusb2repeat: N/A
+pmic-flash: N/A
+pmic-fuelgauge: N/A
+pmic-gpio:
+pmic-haptics: N/A
+pmic-keypad: N/A
+pmic-labib: N/A
+pmic-lpg: N/A
+pmic-mpp: N/A
+pmic-pon: N/A
+pmic-qnovo: N/A
+pmic-regulators:
+pmic-resin: N/A
+pmic-rtc: N/A
+pmic-tempalarm: N/A
+pmic-usb-extcon: N/A
+pmic-usb-typecpd: N/A
+pmic-watchdog: N/A
+pmic-wled: N/A
+---

--- a/_soc/sm4450.md
+++ b/_soc/sm4450.md
@@ -1,0 +1,102 @@
+---
+name: SM4450
+layout: soc
+status-audio-adspaudio:
+status-audio-adspelite: N/A
+status-audio-analogcodec: N/A
+status-audio-dmic: N/A
+status-audio-headset: N/A
+status-audio-i2s: N/A
+status-audio-lpascodecs: N/A
+status-audio-lpasslpi: N/A
+status-audio-slimbus:
+status-audio-soundwire: N/A
+status-audio-spdif: N/A
+status-camera:
+status-camera-csi: N/A
+status-camera-datapath: N/A
+status-camera-eva: N/A
+status-camera-i2c:
+status-camera-sfe: N/A
+status-camera-vfe: N/A
+status-camera-vfelight: N/A
+status-clock-gcc:
+status-clock-rpmhcc:
+status-clock-tcsrcc:
+status-connectivity-bluetooth:
+status-connectivity-ethernet: N/A
+status-connectivity-ipa:
+status-connectivity-wlan:
+status-cpu-bwmon:
+status-cpu-cachetop: N/A
+status-cpu-cpufreq:
+status-cpu-cpuidle: 6.6
+status-cpu-ddrfreq:
+status-cpu-l3cache:
+status-cpu-llcc:
+status-cpu-smp: 6.6
+status-cpu-smp-comment:
+status-crypto-qcrypto:
+status-crypto-rng: N/A
+status-debug-coresight: N/A
+status-debug-dcc:
+status-debug-eud:
+status-display-dp:
+status-display-dsi: N/A
+status-display-hdmi: N/A
+status-display-hdmiaudio: N/A
+status-display-hdmicec: N/A
+status-display-gpu:
+status-display-lvds: N/A
+status-dma-bam:
+status-dma-gpi:
+status-gnss: N/A
+status-hwspinlocks: N/A
+status-i2c:
+status-interconnects:
+status-msgbox: N/A
+status-pcie:
+status-pcie-comment: N/A
+status-pinctrl: 6.7
+status-powerthermal-currentlimit: N/A
+status-powerthermal-lmh: N/A
+status-powerthermal-mpm: N/A
+status-powerthermal-pdc: N/A
+status-powerthermal-spm: N/A
+status-powerthermal-tsens:
+status-psci-comment:
+status-qfprom:
+status-remoteproc:
+status-remoteproc-adsp: N/A
+status-remoteproc-cdsp:
+status-remoteproc-fastrpc:
+status-remoteproc-mdsp: N/A
+status-remoteproc-sdsp: N/A
+status-smmu:
+status-spi:
+status-spmi:
+status-sram-imem: N/A
+status-sram-rpmh-stats:
+status-storage-emmcice: N/A
+status-storage-nand: N/A
+status-storage-sata: N/A
+status-storage-sdcc: N/A
+status-storage-ufs:
+status-storage-ufsice:
+status-storage-ufsice-comment: N/A
+status-uart: 6.6
+status-usb:
+status-usb-comment: N/A
+status-usb-hostmode:
+status-usb-periphmode:
+status-usb-typec:
+status-usb-usb4:
+status-usb-usbotg:
+status-video-venus: N/A
+status-watchdog:
+pmic: pm4450, pm4450c, pmg1110, pm8010, pm3001a
+---
+Snapdragon 4 Gen 2
+
+Tested Boards:
+- SM4450-QRD


### PR DESCRIPTION
Add entries for SM4450-QRD and pmics used by it to show test results
for upstream kernel on this platform. 