### PR TITLE
soc: update sm4450 to follow actual upstream status

### DIFF
--- a/_soc/sm4450.md
+++ b/_soc/sm4450.md
@@ -1,99 +1,94 @@
 ---
 name: SM4450
 layout: soc
-status-audio-adspaudio:
+status-audio-adspaudio: N
 status-audio-adspelite: N/A
 status-audio-analogcodec: N/A
-status-audio-dmic: N/A
+status-audio-dmic: N
 status-audio-headset: N/A
-status-audio-i2s: N/A
-status-audio-lpascodecs: N/A
-status-audio-lpasslpi: N/A
-status-audio-slimbus:
-status-audio-soundwire: N/A
+status-audio-i2s: N
+status-audio-lpascodecs: N
+status-audio-lpasslpi: N
+status-audio-slimbus: N
+status-audio-soundwire: N
 status-audio-spdif: N/A
-status-camera:
-status-camera-csi: N/A
-status-camera-datapath: N/A
+status-camera: N
+status-camera-csi: N
+status-camera-datapath: N
 status-camera-eva: N/A
-status-camera-i2c:
+status-camera-i2c: N
 status-camera-sfe: N/A
-status-camera-vfe: N/A
+status-camera-vfe: N
 status-camera-vfelight: N/A
-status-clock-gcc:
-status-clock-rpmhcc:
-status-clock-tcsrcc:
-status-connectivity-bluetooth:
+status-clock-gcc: 6.8
+status-clock-rpmhcc: 6.8
+status-clock-tcsrcc: N/A
+status-connectivity-bluetooth: N
 status-connectivity-ethernet: N/A
-status-connectivity-ipa:
-status-connectivity-wlan:
-status-cpu-bwmon:
+status-connectivity-ipa: 
+status-connectivity-wlan: N
+status-cpu-bwmon: N
 status-cpu-cachetop: N/A
-status-cpu-cpufreq:
+status-cpu-cpufreq: WIP
 status-cpu-cpuidle: 6.6
-status-cpu-ddrfreq:
+status-cpu-ddrfreq: N
 status-cpu-l3cache:
-status-cpu-llcc:
+status-cpu-llcc: N
 status-cpu-smp: 6.6
-status-cpu-smp-comment:
 status-crypto-qcrypto:
 status-crypto-rng: N/A
 status-debug-coresight: N/A
 status-debug-dcc:
 status-debug-eud:
 status-display-dp:
-status-display-dsi: N/A
+status-display-dsi: N
 status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
-status-display-gpu:
+status-display-gpu: N
 status-display-lvds: N/A
-status-dma-bam:
-status-dma-gpi:
+status-dma-bam: N
+status-dma-gpi: N
 status-gnss: N/A
-status-hwspinlocks: N/A
-status-i2c:
-status-interconnects:
-status-msgbox: N/A
-status-pcie:
-status-pcie-comment: N/A
-status-pinctrl: 6.7
+status-hwspinlocks: 6.6
+status-i2c: N
+status-interconnects: N
+status-msgbox: N
+status-pcie: N/A
+status-pinctrl: 6.8
 status-powerthermal-currentlimit: N/A
 status-powerthermal-lmh: N/A
 status-powerthermal-mpm: N/A
 status-powerthermal-pdc: N/A
 status-powerthermal-spm: N/A
-status-powerthermal-tsens:
-status-psci-comment:
-status-qfprom:
-status-remoteproc:
-status-remoteproc-adsp: N/A
-status-remoteproc-cdsp:
-status-remoteproc-fastrpc:
+status-powerthermal-tsens: N
+status-qfprom: N
+status-remoteproc: N
+status-remoteproc-adsp: N
+status-remoteproc-cdsp: N
+status-remoteproc-fastrpc: N
 status-remoteproc-mdsp: N/A
 status-remoteproc-sdsp: N/A
-status-smmu:
-status-spi:
-status-spmi:
-status-sram-imem: N/A
-status-sram-rpmh-stats:
+status-smmu: N
+status-spi: N
+status-spmi: N
+status-sram-imem: N
+status-sram-rpmh-stats: N
 status-storage-emmcice: N/A
 status-storage-nand: N/A
 status-storage-sata: N/A
-status-storage-sdcc: N/A
+status-storage-sdcc: N
 status-storage-ufs:
-status-storage-ufsice:
-status-storage-ufsice-comment: N/A
+status-storage-ufsice: N/A
 status-uart: 6.6
-status-usb:
-status-usb-comment: N/A
+status-usb: N
 status-usb-hostmode:
 status-usb-periphmode:
 status-usb-typec:
 status-usb-usb4:
 status-usb-usbotg:
 status-video-venus: N/A
-status-watchdog:
+status-watchdog: N
 pmic: pm4450, pm4450c, pmg1110, pm8010, pm3001a
 ---
 Snapdragon 4 Gen 2


### PR DESCRIPTION
Fix few missing entries (like gcc or spinlocks)
Move N/A from comments to the main entry
Mark unsupported-but-present-in-hardware features with explicit N

Cc: YijieYang <quic_yijiyang@quicinc.com>