### PR TITLE
soc/sdx75: add status for SDX75

### DIFF
--- a/_pmic/pm7550ba.md
+++ b/_pmic/pm7550ba.md
@@ -1,5 +1,5 @@
 ---
-name: PMK8550
+name: PM7550BA
 layout: pmic
 pmic-adc-gpadc: N/A
 pmic-adc-iadc: N/A
@@ -14,21 +14,21 @@ pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
 pmic-fuelgauge: N/A
-pmic-gpio: 6.3
+pmic-gpio: 6.6
 pmic-haptics: N/A
 pmic-keypad: N/A
 pmic-labib: N/A
 pmic-lpg: N/A
 pmic-mpp: N/A
-pmic-pon: 6.3
+pmic-pon: N/A
 pmic-qnovo: N/A
 pmic-regulators: N/A
 pmic-resin: N
-pmic-rtc: 6.3
+pmic-rtc: N/A
 pmic-tempalarm: N/A
 pmic-usb-extcon: N/A
 pmic-usb-typecpd: N/A
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SM8550](../soc/sm8550) and [SDX75](../soc/sdx75) platforms.
+This PMIC is usually used with the [SDX75](../soc/sdx75) platform.

--- a/_pmic/pmx75.md
+++ b/_pmic/pmx75.md
@@ -1,5 +1,5 @@
 ---
-name: PMK8550
+name: PMX75
 layout: pmic
 pmic-adc-gpadc: N/A
 pmic-adc-iadc: N/A
@@ -14,21 +14,21 @@ pmic-coincell: N/A
 pmic-eusb2repeat: N/A
 pmic-flash: N/A
 pmic-fuelgauge: N/A
-pmic-gpio: 6.3
+pmic-gpio: 6.6
 pmic-haptics: N/A
 pmic-keypad: N/A
 pmic-labib: N/A
 pmic-lpg: N/A
 pmic-mpp: N/A
-pmic-pon: 6.3
+pmic-pon: N/A
 pmic-qnovo: N/A
 pmic-regulators: N/A
 pmic-resin: N
-pmic-rtc: 6.3
+pmic-rtc: N/A
 pmic-tempalarm: N/A
 pmic-usb-extcon: N/A
 pmic-usb-typecpd: N/A
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SM8550](../soc/sm8550) and [SDX75](../soc/sdx75) platforms.
+This PMIC is usually used with the [SDX75](../soc/sdx75) platform.

--- a/_soc/sdx75.md
+++ b/_soc/sdx75.md
@@ -1,0 +1,96 @@
+---
+name: SDX75
+layout: soc
+status-audio-adspaudio: N/A
+status-audio-adspelite: N/A
+status-audio-analogcodec: N/A
+status-audio-dmic: N/A
+status-audio-headset: N/A
+status-audio-i2s: N/A
+status-audio-lpascodecs: N/A
+status-audio-lpasslpi: N/A
+status-audio-slimbus: N/A
+status-audio-soundwire: N/A
+status-audio-spdif: N/A
+status-camera: N/A
+status-camera-csi: N/A
+status-camera-datapath: N/A
+status-camera-eva: N/A
+status-camera-i2c: N/A
+status-camera-sfe: N/A
+status-camera-vfe: N/A
+status-camera-vfelight: N/A
+status-clock-gcc: 6.5
+status-clock-rpmhcc: 6.5
+status-clock-tcsrcc: N/A
+status-connectivity-bluetooth: N/A
+status-connectivity-ethernet: N/A
+status-connectivity-ipa: WIP
+status-connectivity-wlan: N/A
+status-cpu-bwmon: WIP
+status-cpu-cachetop: 6.5
+status-cpu-cpufreq: 6.5
+status-cpu-cpuidle: 6.5
+status-cpu-ddrfreq:
+status-cpu-l3cache: 6.5
+status-cpu-llcc: WIP
+status-cpu-smp: 6.5
+status-crypto-qcrypto: N/A
+status-crypto-rng: N/A
+status-debug-coresight: N/A
+status-debug-dcc: N/A
+status-debug-eud: WIP
+status-display-dp: N/A
+status-display-dsi: N/A
+status-display-hdmi: N/A
+status-display-hdmiaudio: N/A
+status-display-hdmicec: N/A
+status-display-kgsl: N/A
+status-display-lvds: N/A
+status-dma-bam: WIP
+status-dma-gpi: N/A
+status-gnss: N/A
+status-hwspinlocks: 6.5
+status-i2c: 6.11
+status-interconnects: 6.8
+status-pcie: WIP
+status-pinctrl: 6.5
+status-powerthermal-currentlimit:
+status-powerthermal-lmh:
+status-powerthermal-mpm:
+status-powerthermal-pdc: 6.5
+status-powerthermal-spm:
+status-powerthermal-tsens:
+status-qfprom:
+status-remoteproc: 6.12
+status-remoteproc-adsp: N/A
+status-remoteproc-cdsp: N/A
+status-remoteproc-fastrpc: N/A
+status-remoteproc-mdsp: 6.12
+status-remoteproc-sdsp: N/A
+status-smmu: 6.5
+status-spi: 6.11
+status-spmi: 6.6
+status-sram-imem: WIP
+status-sram-rpmh-stats:
+status-storage-emmcice: N/A
+status-storage-nand: WIP
+status-storage-sata: N/A
+status-storage-sdcc: 6.11
+status-storage-ufs: N/A
+status-storage-ufsice: N/A
+status-uart: 6.5
+status-usb: 6.8
+status-usb-hostmode:
+status-usb-periphmode: 6.8
+status-usb-typec: WIP
+status-usb-usb4:
+status-usb-usbotg:
+status-video-venus: N/A
+status-watchdog:
+pmic: pm7550ba, pmk8550, pmx75
+---
+SDX75
+
+Tested Boards:
+- SDX75-IDP


### PR DESCRIPTION
SDX75 is one of the Qualcomm platforms supported by upstream.
Describe its status.
Also add the SDX75 PMICs.