### PR TITLE
_soc: update for pending 6.16 bits

### DIFF
--- a/_soc/qcs615.md
+++ b/_soc/qcs615.md
@@ -34,6 +34,7 @@ status-cpu-ddrfreq:
 status-cpu-l3cache: 6.14
 status-cpu-llcc: 6.14
 status-cpu-smp: 6.14
+status-crypto-qcrypto: next-6.16
 status-crypto-rng: next-6.16
 status-debug-coresight: 6.14
 status-debug-dcc:

--- a/_soc/sm8750.md
+++ b/_soc/sm8750.md
@@ -33,7 +33,7 @@ status-cpu-cpufreq: 6.14
 status-cpu-cpuidle: 6.14
 status-cpu-ddrfreq:
 status-cpu-l3cache:
-status-cpu-llcc: mailing list
+status-cpu-llcc: next-6.16
 status-cpu-smp:
 status-crypto-qcrypto: next-6.16
 status-crypto-rng: next-6.16


### PR DESCRIPTION
Follow the linux-next shaping for 6.16 and update pending status.