### PR TITLE
soc: drop hwspinlock and mbox status tags

### DIFF
--- a/_soc/apq8064.md
+++ b/_soc/apq8064.md
@@ -26,7 +26,6 @@ status-display-hdmi: 4.10
 status-display-lvds: 4.10
 status-dma-bam: 3.18
 status-dma-gpi: N/A
-status-hwspinlocks: 4.1
 status-i2c: 3.18
 status-interconnects: N
 status-pcie: 4.5

--- a/_soc/qcm2290.md
+++ b/_soc/qcm2290.md
@@ -52,7 +52,6 @@ status-display-lvds: N/A
 status-dma-bam:
 status-dma-gpi: 6.4
 status-gnss: N/A
-status-hwspinlocks: 6.4
 status-i2c: 6.4
 status-interconnects: 6.8
 status-msgbox: 6.4

--- a/_soc/qcs615.md
+++ b/_soc/qcs615.md
@@ -49,7 +49,6 @@ status-display-lvds: N/A
 status-dma-bam: 6.14
 status-dma-gpi: 6.14
 status-gnss: N/A
-status-hwspinlocks: 6.14
 status-i2c: 6.14
 status-interconnects: 6.14
 status-msgbox: 6.14

--- a/_soc/qcs8300.md
+++ b/_soc/qcs8300.md
@@ -51,7 +51,6 @@ status-display-lvds: N/A
 status-dma-bam:
 status-dma-gpi:
 status-gnss:
-status-hwspinlocks: 6.14
 status-i2c:
 status-interconnects: 6.14
 status-msgbox:

--- a/_soc/qdu1000.md
+++ b/_soc/qdu1000.md
@@ -49,7 +49,6 @@ status-display-lvds: N/A
 status-dma-bam: N/A
 status-dma-gpi: 6.3
 status-gnss:
-status-hwspinlocks: 6.3
 status-i2c: 6.3
 status-interconnects: 6.3
 status-msgbox:

--- a/_soc/sar2130p.md
+++ b/_soc/sar2130p.md
@@ -57,7 +57,6 @@ status-dma-bam:
 status-dma-gpi: 6.13
 status-dma-gpi-comment: DT bits in 6.14
 status-gnss:
-status-hwspinlocks: 6.14
 status-i2c: 6.14
 status-interconnects: 6.13
 status-interconnects-comment: DT bits in 6.14

--- a/_soc/sc7280.md
+++ b/_soc/sc7280.md
@@ -51,7 +51,6 @@ status-display-lvds: N/A
 status-dma-bam:
 status-dma-gpi: 5.19
 status-gnss:
-status-hwspinlocks:
 status-i2c: 5.16
 status-interconnects: 5.14
 status-msgbox:

--- a/_soc/sc8180x.md
+++ b/_soc/sc8180x.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam: N/A
 status-dma-gpi: N/A
 status-gnss: N/A
-status-hwspinlocks: N/A
 status-i2c: 6.5
 status-interconnects: 6.5
 status-msgbox: 6.5

--- a/_soc/sdx65.md
+++ b/_soc/sdx65.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam: 6.0
 status-dma-gpi: N/A
 status-gnss: N/A
-status-hwspinlocks: 5.19
 status-i2c: N/A
 status-interconnects: 5.19
 status-pcie: 6.5

--- a/_soc/sm4450.md
+++ b/_soc/sm4450.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam: N
 status-dma-gpi: N
 status-gnss: N/A
-status-hwspinlocks: 6.6
 status-i2c: N
 status-interconnects: N
 status-msgbox: N

--- a/_soc/sm6115.md
+++ b/_soc/sm6115.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam: N/A
 status-dma-gpi: 6.2
 status-gnss: N/A
-status-hwspinlocks: N/A
 status-i2c: 6.2
 status-interconnects: 6.8
 status-msgbox: 6.2

--- a/_soc/sm6350.md
+++ b/_soc/sm6350.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam:
 status-dma-gpi: 6.1
 status-gnss:
-status-hwspinlocks:
 status-i2c: 5.19
 status-interconnects: 6.1
 status-msgbox: 5.16

--- a/_soc/sm8450.md
+++ b/_soc/sm8450.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam: WIP
 status-dma-gpi: 5.17
 status-gnss:
-status-hwspinlocks:
 status-i2c: 5.17
 status-interconnects: 5.17
 status-pcie: 5.18

--- a/_soc/sm8550.md
+++ b/_soc/sm8550.md
@@ -51,7 +51,6 @@ status-display-lvds: N/A
 status-dma-bam: 6.3
 status-dma-gpi: 6.3
 status-gnss:
-status-hwspinlocks:
 status-i2c: 6.3
 status-interconnects: 6.3
 status-msgbox:

--- a/_soc/sm8650.md
+++ b/_soc/sm8650.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam: 6.3
 status-dma-gpi: 6.3
 status-gnss:
-status-hwspinlocks:
 status-i2c: 6.3
 status-interconnects: 6.8
 status-msgbox:

--- a/_soc/sm8750.md
+++ b/_soc/sm8750.md
@@ -50,7 +50,6 @@ status-display-lvds: N/A
 status-dma-bam:
 status-dma-gpi: 6.14
 status-gnss:
-status-hwspinlocks:
 status-i2c: 6.14
 status-interconnects: 6.14
 status-msgbox:

--- a/_soc/x1e80100.md
+++ b/_soc/x1e80100.md
@@ -51,7 +51,6 @@ status-display-lvds: N/A
 status-dma-bam: N
 status-dma-gpi: 6.8
 status-gnss:
-status-hwspinlocks:
 status-i2c: 6.8
 status-interconnects: 6.8
 status-msgbox: 6.9

--- a/soc.yaml
+++ b/soc.yaml
@@ -219,10 +219,6 @@ dma:
       name: GPI
     bam:
       name: BAM
-hwspinlocks:
-  name: HW Spinlocks
-msgbox:
-  name: MsgBox
 qfprom:
   name: QFPROM
 powerthermal:


### PR DESCRIPTION
Both TCSR hw mutex and APCS mbox are too low-level to be important on their own. Drop them from the status pages, as we usually don't list other low-level devices.