### PR TITLE
soc: hide NAND storage from the main page

### DIFF
--- a/soc.yaml
+++ b/soc.yaml
@@ -42,7 +42,6 @@ storage:
   items:
     nand:
       name: NAND
-      intop: True
     sata:
       name: SATA
     ufs:


### PR DESCRIPTION
Most of the platforms (except modems) don't have hardware support for NAND storage. Remove the column from the main page.