### PR TITLE
pmic: Update by using unified platform names of each soc

### DIFF
--- a/_pmic/pm4125.md
+++ b/_pmic/pm4125.md
@@ -31,4 +31,4 @@ pmic-usb-typecpd: 6.9
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [QRB2210](../soc/qcm2290) platform.
+This PMIC is usually used with the [Agatti](../soc/agatti) platform.

--- a/_pmic/pm7250b.md
+++ b/_pmic/pm7250b.md
@@ -31,4 +31,4 @@ pmic-usb-typecpd: 6.11
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SDX65](../soc/sdx65), [QCM6490](../soc/sc7280), [SM6350](../soc/sm6350) platforms.
+This PMIC is usually used with the [Kodiak](../soc/kodiak), [SDX65](../soc/sdx65), [SM6350](../soc/sm6350) platforms.

--- a/_pmic/pm8350.md
+++ b/_pmic/pm8350.md
@@ -31,4 +31,4 @@ pmic-usb-typecpd: N/A
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SM8450](../soc/sm8450), [SM8350](../soc/sm8350) & sc7280 platforms.
+This PMIC is usually used with the [Kodiak](../soc/kodiak), [SM8450](../soc/sm8450), [SM8350](../soc/sm8350) platforms.

--- a/_pmic/pm8350c.md
+++ b/_pmic/pm8350c.md
@@ -31,4 +31,4 @@ pmic-usb-typecpd: N/A
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SM8450](../soc/sm8450), [SM8350](../soc/sm8350) & sc7280 platforms.
+This PMIC is usually used with the [Kodiak](../soc/kodiak), [SM8450](../soc/sm8450), [SM8350](../soc/sm8350) platforms.

--- a/_pmic/pmk8350.md
+++ b/_pmic/pmk8350.md
@@ -31,4 +31,4 @@ pmic-usb-typecpd: N/A
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SM8450](../soc/sm8450), [SM8350](../soc/sm8350), [SDX65](../soc/sdx65), sc7280, sm6375 & sm7225 platforms.
+This PMIC is usually used with the [Kodiak](../soc/kodiak), [SM8450](../soc/sm8450), [SM8350](../soc/sm8350), [SDX65](../soc/sdx65), sm6375 & sm7225 platforms.

--- a/_pmic/pmr735a.md
+++ b/_pmic/pmr735a.md
@@ -31,4 +31,4 @@ pmic-usb-typecpd: N/A
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [SM8450](../soc/sm8450), [SM8350](../soc/sm8350), sc7280 & sm6375 platforms.
+This PMIC is usually used with the [Kodiak](../soc/kodiak), [SM8450](../soc/sm8450), [SM8350](../soc/sm8350), & sm6375 platforms.

--- a/_pmic/smb2360.md
+++ b/_pmic/smb2360.md
@@ -31,4 +31,4 @@ pmic-usb-typecpd: N
 pmic-watchdog: N/A
 pmic-wled: N/A
 ---
-This PMIC is usually used with the [X1E80100](../soc/x1e80100) platform.
+This PMIC is usually used with the [Hamoa](../soc/hamoa) platform.


### PR DESCRIPTION
Unified platform name list:
* Kodiak for sc7280
* Agatti for qcm2290
* Hamoa for x1e80100