### PR TITLE
msm8660/msm8260/apq8060 status audit

### DIFF
--- a/_pmic/pm8058.md
+++ b/_pmic/pm8058.md
@@ -1,0 +1,34 @@
+---
+name: PM8058
+layout: pmic
+pmic-adc-gpadc: N/A
+pmic-adc-iadc: N/A
+pmic-adc-rradc: N/A
+pmic-adc-thermal: Working, pending submission
+pmic-adc-touch: N/A
+pmic-adc-vadc: 4.8
+pmic-audiocodec: N/A
+pmic-bms: N/A
+pmic-clkdiv: N/A
+pmic-coincell: Working, pending submission
+pmic-eusb2repeat: N/A
+pmic-flash: N/A
+pmic-fuelgauge: N/A
+pmic-gpio: 4.8
+pmic-haptics: N/A
+pmic-keypad: 4.8
+pmic-labib: N/A
+pmic-lpg: 4.8
+pmic-mpp: 4.8
+pmic-pon: N/A
+pmic-qnovo: N/A
+pmic-regulators: 4.8
+pmic-resin: N/A
+pmic-rtc: 4.8
+pmic-tempalarm: N/A
+pmic-usb-extcon: N/A
+pmic-usb-typecpd: N/A
+pmic-watchdog: N/A
+pmic-wled: N/A
+---
+This PMIC is usually used with the [MSM8660](../soc/msm8660) SoC.

--- a/_pmic/pm8901.md
+++ b/_pmic/pm8901.md
@@ -1,0 +1,34 @@
+---
+name: PM8901
+layout: pmic
+pmic-adc-gpadc: N/A
+pmic-adc-iadc: N/A
+pmic-adc-rradc: N/A
+pmic-adc-thermal: N/A
+pmic-adc-touch: N/A
+pmic-adc-vadc: N/A
+pmic-audiocodec: N/A
+pmic-bms: N/A
+pmic-clkdiv: N/A
+pmic-coincell: N/A
+pmic-eusb2repeat: N/A
+pmic-flash: N/A
+pmic-fuelgauge: N/A
+pmic-gpio: N/A
+pmic-haptics: N/A
+pmic-keypad: N/A
+pmic-labib: N/A
+pmic-lpg: N/A
+pmic-mpp: Working, pending submission
+pmic-pon: N/A
+pmic-qnovo: N/A
+pmic-regulators: 4.8
+pmic-resin: N/A
+pmic-rtc: N/A
+pmic-tempalarm: Working, pending submission
+pmic-usb-extcon: N/A
+pmic-usb-typecpd: N/A
+pmic-watchdog: N/A
+pmic-wled: N/A
+---
+This PMIC is usually used with the [MSM8660](../soc/msm8660) SoC.

--- a/_soc/agatti.md
+++ b/_soc/agatti.md
@@ -50,7 +50,8 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
-status-dma-bam:
+status-dma-adm: N/A
+status-dma-bam: N/A
 status-dma-gpi: 6.4
 status-gnss: N/A
 status-i2c: 6.4

--- a/_soc/agatti.md
+++ b/_soc/agatti.md
@@ -71,7 +71,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N/A
 status-remoteproc-mdsp: 6.4
 status-remoteproc-sdsp: N/A
-status-smmu: 6.4
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.4
 status-spi: 6.4
 status-spmi: 6.4
 status-sram-imem: N/A

--- a/_soc/agatti.md
+++ b/_soc/agatti.md
@@ -92,6 +92,7 @@ status-usb-typec: 6.10
 status-usb-usb4: N/A
 status-usb-usbotg: 6.10
 status-video-venus: 6.18
+status-video-vidc: N/A
 status-watchdog: 6.4
 pmic: pm4125
 ---

--- a/_soc/apq8060.md
+++ b/_soc/apq8060.md
@@ -1,0 +1,95 @@
+---
+name: APQ8060
+fullname: Snapdragon S3
+layout: soc
+status-audio-adspaudio: WIP
+status-audio-adspelite: N/A
+status-audio-analogcodec: Working, pending submission
+status-audio-dmic: N/A
+status-audio-headset: N/A
+status-audio-i2s: Working, pending submission
+status-audio-lpascodecs: N/A
+status-audio-lpasslpi: N/A
+status-audio-slimbus: N/A
+status-audio-soundwire: N/A
+status-audio-spdif: N/A
+status-camera: Working, pending submission
+status-camera-csi: Working, pending submission
+status-camera-datapath: N/A
+status-camera-eva: N/A
+status-camera-i2c: N/A
+status-camera-sfe: N/A
+status-camera-vfe: Working, pending submission
+status-camera-vfelight: N/A
+status-clock-gcc: 3.14
+status-clock-rpmhcc: 4.15
+status-clock-tcsrcc: N/A
+status-connectivity-bluetooth: WIP
+status-connectivity-ethernet: N/A
+status-connectivity-ipa: N/A
+status-connectivity-wlan: WIP
+status-cpu-bwmon: N/A
+status-cpu-cachetop: N/A
+status-cpu-cpufreq: Working, pending submission
+status-cpu-cpuidle: Working, pending submission
+status-cpu-ddrfreq: N/A
+status-cpu-l3cache: N/A
+status-cpu-llcc: N/A
+status-cpu-smp: Working, pending submission
+status-crypto-qcrypto: Working, pending submission
+status-crypto-rng: Working, pending submission
+status-debug-coresight: N/A
+status-debug-dcc: N/A
+status-debug-eud: N/A
+status-display-dp: N/A
+status-display-dsi: N/A
+status-display-gpu: Working, pending submission
+status-display-hdmi: N/A
+status-display-hdmiaudio: N/A
+status-display-hdmicec: N/A
+status-display-lvds: Working, pending submission
+status-dma-adm: Working, pending submission
+status-dma-bam: N/A
+status-dma-gpi: N/A
+status-gnss: N/A
+status-i2c: 4.8
+status-interconnects: Working, pending submission
+status-pcie: N/A
+status-pinctrl: 4.2
+status-powerthermal-currentlimit: N/A
+status-powerthermal-lmh: N/A
+status-powerthermal-mpm: Working, pending submission
+status-powerthermal-pdc: N/A
+status-powerthermal-spm: Working, pending submission
+status-powerthermal-tsens: N/A
+status-qfprom: Working, pending submission
+status-remoteproc: Working, pending submission
+status-remoteproc-adsp: Working, pending submission
+status-remoteproc-cdsp: N/A
+status-remoteproc-fastrpc: N/A
+status-remoteproc-mdsp: N/A
+status-remoteproc-sdsp: N/A
+status-mmu-iommu: Working, pending submission
+status-mmu-smmu: N/A
+status-spi: 4.8
+status-spmi: N/A
+status-sram-imem: N/A
+status-sram-rpmh-stats: N/A
+status-storage-emmcice: N/A
+status-storage-nand: N/A
+status-storage-sata: N/A
+status-storage-sdcc: Working, pending submission
+status-storage-ufs: N/A
+status-storage-ufsice: N/A
+status-uart: 4.8
+status-usb: Working, pending submission
+status-usb-hostmode: Working, pending submission
+status-usb-periphmode: Working, pending submission
+status-usb-typec: N/A
+status-usb-usb4: N/A
+status-usb-usbotg: N/A
+status-video-venus: N/A
+status-video-vidc: Working, pending submission
+status-watchdog: 4.8
+pmic: pm8058, pm8901
+---

--- a/_soc/apq8064.md
+++ b/_soc/apq8064.md
@@ -40,7 +40,8 @@ status-remoteproc-adsp: 4.7
 status-remoteproc-cdsp: N/A
 status-remoteproc-mdsp: 4.7
 status-remoteproc-sdsp: 4.7
-status-smmu: 4.10
+status-mmu-iommu: N/A
+status-mmu-smmu: 4.10
 status-spi: 4.6
 status-spmi: 3.16
 status-spmi-comment: This SoC uses SSBI to communicate with PMICs

--- a/_soc/apq8064.md
+++ b/_soc/apq8064.md
@@ -25,6 +25,7 @@ status-display-dsi: 4.10
 status-display-gpu: 4.10
 status-display-hdmi: 4.10
 status-display-lvds: 4.10
+status-dma-adm: N/A
 status-dma-bam: 3.18
 status-dma-gpi: N/A
 status-i2c: 3.18

--- a/_soc/apq8064.md
+++ b/_soc/apq8064.md
@@ -59,6 +59,7 @@ status-usb-periphmode: 4.2
 status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: 4.2
+status-video-vidc: N/A
 status-watchdog: 3.19
 ---
 Tested boards:

--- a/_soc/hamoa.md
+++ b/_soc/hamoa.md
@@ -71,7 +71,8 @@ status-remoteproc-cdsp: 6.9
 status-remoteproc-fastrpc: "6.10"
 status-remoteproc-mdsp: N
 status-remoteproc-sdsp: N
-status-smmu: 6.8
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.8
 status-spi: 6.8
 status-spmi: "6.10"
 status-sram-imem:

--- a/_soc/hamoa.md
+++ b/_soc/hamoa.md
@@ -92,6 +92,7 @@ status-usb-typec: 6.11
 status-usb-usb4:
 status-usb-usbotg: 6.11
 status-video-venus: N
+status-video-vidc: N/A
 status-watchdog: 6.15
 pmic: pm8550, pm8550ve, pmc8380, smb2360
 ---

--- a/_soc/hamoa.md
+++ b/_soc/hamoa.md
@@ -50,6 +50,7 @@ status-display-hdmicec: N/A
 status-display-gpu: 6.10
 status-display-gpu-comment: DT bits in 6.11
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N
 status-dma-gpi: 6.8
 status-gnss:

--- a/_soc/kamorta.md
+++ b/_soc/kamorta.md
@@ -70,7 +70,8 @@ status-remoteproc-cdsp: 6.4
 status-remoteproc-fastrpc: 6.4
 status-remoteproc-mdsp: 6.4
 status-remoteproc-sdsp: N/A
-status-smmu: 6.2
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.2
 status-spi: 6.2
 status-spmi: 6.2
 status-sram-imem: N/A

--- a/_soc/kamorta.md
+++ b/_soc/kamorta.md
@@ -49,6 +49,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N/A
 status-dma-gpi: 6.2
 status-gnss: N/A

--- a/_soc/kamorta.md
+++ b/_soc/kamorta.md
@@ -91,6 +91,7 @@ status-usb-typec: 6.9
 status-usb-usb4: N/A
 status-usb-usbotg: 6.9
 status-video-venus: N/A
+status-video-vidc: N/A
 status-watchdog: 6.3
 ---
 Tested Boards:

--- a/_soc/kodiak.md
+++ b/_soc/kodiak.md
@@ -92,6 +92,7 @@ status-usb-typec: 6.9
 status-usb-usb4:
 status-usb-usbotg: 6.9
 status-video-venus: 5.17
+status-video-vidc: N/A
 status-watchdog: 5.13
 pmic: pm7250b, pm7325, pm8350c, pmk8350, pmr735a
 ---

--- a/_soc/kodiak.md
+++ b/_soc/kodiak.md
@@ -71,7 +71,8 @@ status-remoteproc-cdsp: 6.8
 status-remoteproc-fastrpc: 6.8
 status-remoteproc-mdsp: 5.16
 status-remoteproc-sdsp:
-status-smmu: 5.13
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.13
 status-spi: 5.16
 status-spmi: 5.13
 status-sram-imem: 5.16

--- a/_soc/kodiak.md
+++ b/_soc/kodiak.md
@@ -50,6 +50,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: 5.16
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam:
 status-dma-gpi: 5.19
 status-gnss:

--- a/_soc/lemans.md
+++ b/_soc/lemans.md
@@ -43,6 +43,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 6.13
 status-dma-gpi: 6.13
 status-gnss: N

--- a/_soc/lemans.md
+++ b/_soc/lemans.md
@@ -79,6 +79,7 @@ status-usb: 6.5
 status-usb-hostmode: 6.5
 status-usb-periphmode: 6.5
 status-video-venus: N
+status-video-vidc: N/A
 status-watchdog: 6.5
 pmic: pmm8654au
 ---

--- a/_soc/lemans.md
+++ b/_soc/lemans.md
@@ -62,7 +62,8 @@ status-remoteproc-cdsp: 6.12
 status-remoteproc-fastrpc: 6.12
 status-remoteproc-mdsp: N/A
 status-remoteproc-sdsp: N/A
-status-smmu: 6.4
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.4
 status-spi: 6.4
 status-spmi: 6.4
 status-sram-imem: 6.11

--- a/_soc/milos.md
+++ b/_soc/milos.md
@@ -100,6 +100,7 @@ status-usb-typec: 7.0
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus:
+status-video-vidc: N/A
 status-watchdog: N/A
 pmic: pm7550, pm8550vs, pmiv0104, pmk8550, pmr735b
 ---

--- a/_soc/milos.md
+++ b/_soc/milos.md
@@ -52,6 +52,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N/A
 status-dma-gpi: 7.0
 status-gnss:

--- a/_soc/milos.md
+++ b/_soc/milos.md
@@ -77,7 +77,8 @@ status-remoteproc-fastrpc:
 status-remoteproc-mdsp: 6.18
 status-remoteproc-mdsp-comment: DT bits in 7.0
 status-remoteproc-sdsp: N/A
-status-smmu: 7.0
+status-mmu-iommu: N/A
+status-mmu-smmu: 7.0
 status-spi: 7.0
 status-spmi: 7.0
 status-sram-imem:

--- a/_soc/monaco.md
+++ b/_soc/monaco.md
@@ -91,6 +91,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus: 6.16
+status-video-vidc: N/A
 status-video-venus-comment: IRIS Driver
 status-watchdog: 6.14
 pmic:

--- a/_soc/monaco.md
+++ b/_soc/monaco.md
@@ -70,7 +70,8 @@ status-remoteproc-cdsp: 6.14
 status-remoteproc-fastrpc: 6.14
 status-remoteproc-mdsp: N/A
 status-remoteproc-sdsp: N/A
-status-smmu: 6.14
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.14
 status-spi:
 status-spmi: 6.16
 status-sram-imem: 6.14

--- a/_soc/monaco.md
+++ b/_soc/monaco.md
@@ -49,6 +49,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam:
 status-dma-gpi:
 status-gnss:

--- a/_soc/msm8226.md
+++ b/_soc/msm8226.md
@@ -48,6 +48,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam:
 status-dma-gpi: N/A
 status-gnss:

--- a/_soc/msm8226.md
+++ b/_soc/msm8226.md
@@ -89,6 +89,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg:
 status-video-venus:
+status-video-vidc: N/A
 status-watchdog: 6.9
 pmic: pm8226
 ---

--- a/_soc/msm8226.md
+++ b/_soc/msm8226.md
@@ -68,7 +68,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N/A
 status-remoteproc-mdsp: 6.16
 status-remoteproc-sdsp: N/A
-status-smmu: N
+status-mmu-iommu: N/A
+status-mmu-smmu: N
 status-spi:
 status-spmi: 5.16
 status-sram-imem: 6.5

--- a/_soc/msm8260.md
+++ b/_soc/msm8260.md
@@ -1,0 +1,95 @@
+---
+name: MSM8260
+fullname: Snapdragon S3
+layout: soc
+status-audio-adspaudio: WIP
+status-audio-adspelite: N/A
+status-audio-analogcodec: Working, pending submission
+status-audio-dmic: N/A
+status-audio-headset: N/A
+status-audio-i2s: Working, pending submission
+status-audio-lpascodecs: N/A
+status-audio-lpasslpi: N/A
+status-audio-slimbus: N/A
+status-audio-soundwire: N/A
+status-audio-spdif: N/A
+status-camera: Working, pending submission
+status-camera-csi: Working, pending submission
+status-camera-datapath: N/A
+status-camera-eva: N/A
+status-camera-i2c: N/A
+status-camera-sfe: N/A
+status-camera-vfe: Working, pending submission
+status-camera-vfelight: N/A
+status-clock-gcc: 3.14
+status-clock-rpmhcc: 4.15
+status-clock-tcsrcc: N/A
+status-connectivity-bluetooth: WIP
+status-connectivity-ethernet: N/A
+status-connectivity-ipa: N/A
+status-connectivity-wlan: WIP
+status-cpu-bwmon: N/A
+status-cpu-cachetop: N/A
+status-cpu-cpufreq: Working, pending submission
+status-cpu-cpuidle: Working, pending submission
+status-cpu-ddrfreq: N/A
+status-cpu-l3cache: N/A
+status-cpu-llcc: N/A
+status-cpu-smp: Working, pending submission
+status-crypto-qcrypto: Working, pending submission
+status-crypto-rng: Working, pending submission
+status-debug-coresight: N/A
+status-debug-dcc: N/A
+status-debug-eud: N/A
+status-display-dp: N/A
+status-display-dsi: N/A
+status-display-gpu: Working, pending submission
+status-display-hdmi: N/A
+status-display-hdmiaudio: N/A
+status-display-hdmicec: N/A
+status-display-lvds: Working, pending submission
+status-dma-adm: Working, pending submission
+status-dma-bam: N/A
+status-dma-gpi: N/A
+status-gnss: N/A
+status-i2c: 4.8
+status-interconnects: Working, pending submission
+status-pcie: N/A
+status-pinctrl: 4.2
+status-powerthermal-currentlimit: N/A
+status-powerthermal-lmh: N/A
+status-powerthermal-mpm: Working, pending submission
+status-powerthermal-pdc: N/A
+status-powerthermal-spm: Working, pending submission
+status-powerthermal-tsens: N/A
+status-qfprom: Working, pending submission
+status-remoteproc: Working, pending submission
+status-remoteproc-adsp: Working, pending submission
+status-remoteproc-cdsp: N/A
+status-remoteproc-fastrpc: N/A
+status-remoteproc-mdsp: N/A
+status-remoteproc-sdsp: N/A
+status-mmu-iommu: Working, pending submission
+status-mmu-smmu: N/A
+status-spi: 4.8
+status-spmi: N/A
+status-sram-imem: N/A
+status-sram-rpmh-stats: N/A
+status-storage-emmcice: N/A
+status-storage-nand: N/A
+status-storage-sata: N/A
+status-storage-sdcc: Working, pending submission
+status-storage-ufs: N/A
+status-storage-ufsice: N/A
+status-uart: 4.8
+status-usb: Working, pending submission
+status-usb-hostmode: Working, pending submission
+status-usb-periphmode: Working, pending submission
+status-usb-typec: N/A
+status-usb-usb4: N/A
+status-usb-usbotg: N/A
+status-video-venus: N/A
+status-video-vidc: Working, pending submission
+status-watchdog: 4.8
+pmic: pm8058, pm8901
+---

--- a/_soc/msm8660.md
+++ b/_soc/msm8660.md
@@ -1,0 +1,95 @@
+---
+name: MSM8660
+fullname: Snapdragon S3
+layout: soc
+status-audio-adspaudio: WIP
+status-audio-adspelite: N/A
+status-audio-analogcodec: Working, pending submission
+status-audio-dmic: N/A
+status-audio-headset: N/A
+status-audio-i2s: Working, pending submission
+status-audio-lpascodecs: N/A
+status-audio-lpasslpi: N/A
+status-audio-slimbus: N/A
+status-audio-soundwire: N/A
+status-audio-spdif: N/A
+status-camera: Working, pending submission
+status-camera-csi: Working, pending submission
+status-camera-datapath: N/A
+status-camera-eva: N/A
+status-camera-i2c: N/A
+status-camera-sfe: N/A
+status-camera-vfe: Working, pending submission
+status-camera-vfelight: N/A
+status-clock-gcc: 3.14
+status-clock-rpmhcc: 4.15
+status-clock-tcsrcc: N/A
+status-connectivity-bluetooth: WIP
+status-connectivity-ethernet: N/A
+status-connectivity-ipa: N/A
+status-connectivity-wlan: WIP
+status-cpu-bwmon: N/A
+status-cpu-cachetop: N/A
+status-cpu-cpufreq: Working, pending submission
+status-cpu-cpuidle: Working, pending submission
+status-cpu-ddrfreq: N/A
+status-cpu-l3cache: N/A
+status-cpu-llcc: N/A
+status-cpu-smp: Working, pending submission
+status-crypto-qcrypto: Working, pending submission
+status-crypto-rng: Working, pending submission
+status-debug-coresight: N/A
+status-debug-dcc: N/A
+status-debug-eud: N/A
+status-display-dp: N/A
+status-display-dsi: N/A
+status-display-gpu: Working, pending submission
+status-display-hdmi: N/A
+status-display-hdmiaudio: N/A
+status-display-hdmicec: N/A
+status-display-lvds: Working, pending submission
+status-dma-adm: Working, pending submission
+status-dma-bam: N/A
+status-dma-gpi: N/A
+status-gnss: N/A
+status-i2c: 4.8
+status-interconnects: Working, pending submission
+status-pcie: N/A
+status-pinctrl: 4.2
+status-powerthermal-currentlimit: N/A
+status-powerthermal-lmh: N/A
+status-powerthermal-mpm: Working, pending submission
+status-powerthermal-pdc: N/A
+status-powerthermal-spm: Working, pending submission
+status-powerthermal-tsens: N/A
+status-qfprom: Working, pending submission
+status-remoteproc: Working, pending submission
+status-remoteproc-adsp: Working, pending submission
+status-remoteproc-cdsp: N/A
+status-remoteproc-fastrpc: N/A
+status-remoteproc-mdsp: N/A
+status-remoteproc-sdsp: N/A
+status-mmu-iommu: Working, pending submission
+status-mmu-smmu: N/A
+status-spi: 4.8
+status-spmi: N/A
+status-sram-imem: N/A
+status-sram-rpmh-stats: N/A
+status-storage-emmcice: N/A
+status-storage-nand: N/A
+status-storage-sata: N/A
+status-storage-sdcc: Working, pending submission
+status-storage-ufs: N/A
+status-storage-ufsice: N/A
+status-uart: 4.8
+status-usb: Working, pending submission
+status-usb-hostmode: Working, pending submission
+status-usb-periphmode: Working, pending submission
+status-usb-typec: N/A
+status-usb-usb4: N/A
+status-usb-usbotg: N/A
+status-video-venus: N/A
+status-video-vidc: Working, pending submission
+status-watchdog: 4.8
+pmic: pm8058, pm8901
+---

--- a/_soc/msm8916.md
+++ b/_soc/msm8916.md
@@ -60,6 +60,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: 4.3
 status-video-venus: 4.14
+status-video-vidc: N/A
 pmic: pm8916
 ---
 Tested Boards:

--- a/_soc/msm8916.md
+++ b/_soc/msm8916.md
@@ -28,6 +28,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: 4.14
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 4.3
 status-i2c: 4.3
 status-interconnects: 5.9

--- a/_soc/msm8916.md
+++ b/_soc/msm8916.md
@@ -41,7 +41,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: 5.7
 status-remoteproc-mdsp: 4.10
 status-remoteproc-sdsp: N/A
-status-smmu: 4.14
+status-mmu-iommu: N/A
+status-mmu-smmu: 4.14
 status-spi: 4.3
 status-spmi: 4.2
 status-sram-rpmh-stats: 5.17

--- a/_soc/msm8939.md
+++ b/_soc/msm8939.md
@@ -62,6 +62,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: 4.3
 status-video-venus: WIP
+status-video-vidc: N/A
 pmic: pm8916
 ---
 Tested Boards:

--- a/_soc/msm8939.md
+++ b/_soc/msm8939.md
@@ -29,6 +29,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: 4.14
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 4.3
 status-i2c: 4.3
 status-interconnects: 5.12

--- a/_soc/msm8939.md
+++ b/_soc/msm8939.md
@@ -43,7 +43,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: 5.7
 status-remoteproc-mdsp: 4.10
 status-remoteproc-sdsp: N/A
-status-smmu: 4.14
+status-mmu-iommu: N/A
+status-mmu-smmu: 4.14
 status-spi: 4.3
 status-spmi: 4.2
 status-sram-rpmh-stats: 5.17

--- a/_soc/msm8953.md
+++ b/_soc/msm8953.md
@@ -50,6 +50,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N/A
 status-dma-gpi: N/A
 status-gnss:

--- a/_soc/msm8953.md
+++ b/_soc/msm8953.md
@@ -72,7 +72,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N
 status-remoteproc-mdsp: 6.4
 status-remoteproc-sdsp: N/A
-status-smmu: 6.2
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.2
 status-spi: 6.8
 status-spmi: 5.18
 status-sram-imem:

--- a/_soc/msm8953.md
+++ b/_soc/msm8953.md
@@ -93,6 +93,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus:
+status-video-vidc: N/A
 status-watchdog:
 pmic: pm8953, pmi8950, pmi632
 ---

--- a/_soc/msm8974.md
+++ b/_soc/msm8974.md
@@ -68,7 +68,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N/A
 status-remoteproc-mdsp: 5.6
 status-remoteproc-sdsp: N/A
-status-smmu: N
+status-mmu-iommu: N/A
+status-mmu-smmu: N
 status-spi:
 status-spmi: 4.1
 status-sram-imem: 5.5

--- a/_soc/msm8974.md
+++ b/_soc/msm8974.md
@@ -90,6 +90,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: 4.11
 status-video-venus:
+status-video-vidc: N/A
 status-watchdog: 6.8
 pmic: pm8841, pm8941
 ---

--- a/_soc/msm8974.md
+++ b/_soc/msm8974.md
@@ -48,6 +48,7 @@ status-display-hdmi:
 status-display-hdmiaudio:
 status-display-hdmicec:
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 4.6
 status-dma-gpi: N/A
 status-gnss:

--- a/_soc/msm8996.md
+++ b/_soc/msm8996.md
@@ -58,6 +58,7 @@ status-usb: 4.14
 status-usb-hostmode: 4.14
 status-usb-periphmode: 4.14
 status-video-venus: 5.4
+status-video-vidc: N/A
 pmic: pm8996, pmi8996
 ---
 Tested Boards:

--- a/_soc/msm8996.md
+++ b/_soc/msm8996.md
@@ -28,6 +28,7 @@ status-display-hdmi: 5.2
 status-display-hdmiaudio: 5.2
 status-display-gpu: 5.2
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 5.2
 status-i2c: 4.8
 status-interconnects: 6.0

--- a/_soc/msm8996.md
+++ b/_soc/msm8996.md
@@ -43,7 +43,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: 6.11
 status-remoteproc-mdsp: 5.19
 status-remoteproc-sdsp: 5.19
-status-smmu: 4.21
+status-mmu-iommu: N/A
+status-mmu-smmu: 4.21
 status-spi: 4.8
 status-spmi: 4.6
 status-sram-rpmh-stats: 5.16

--- a/_soc/msm8998.md
+++ b/_soc/msm8998.md
@@ -56,5 +56,6 @@ status-usb: 5.0
 status-usb-hostmode: 5.0
 status-usb-periphmode: 5.0
 status-video-venus: 6.11
+status-video-vidc: N/A
 pmic: pm8998, pmi8998, pm8005
 ---

--- a/_soc/msm8998.md
+++ b/_soc/msm8998.md
@@ -27,6 +27,7 @@ status-display-hdmi-comment: DT bits in 6.13
 status-display-hdmiaudio: N
 status-display-gpu: 5.15
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 5.4
 status-i2c: 4.8
 status-interconnects: N

--- a/_soc/msm8998.md
+++ b/_soc/msm8998.md
@@ -41,7 +41,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N
 status-remoteproc-mdsp: 5.5
 status-remoteproc-sdsp: 5.5
-status-smmu: 5.15
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.15
 status-spi: 6.4
 status-spmi: 4.19
 status-sram-rpmh-stats: 5.15

--- a/_soc/qdu1000.md
+++ b/_soc/qdu1000.md
@@ -67,7 +67,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N/A
 status-remoteproc-mdsp: WIP
 status-remoteproc-sdsp: N/A
-status-smmu: 6.3
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.3
 status-spi: 6.3
 status-spmi: 6.3
 status-sram-imem: 6.5

--- a/_soc/qdu1000.md
+++ b/_soc/qdu1000.md
@@ -46,6 +46,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N/A
 status-dma-gpi: 6.3
 status-gnss:

--- a/_soc/qdu1000.md
+++ b/_soc/qdu1000.md
@@ -88,6 +88,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus: N/A
+status-video-vidc: N/A
 status-watchdog:
 pmic: pm8150
 ---

--- a/_soc/sar2130p.md
+++ b/_soc/sar2130p.md
@@ -54,6 +54,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam:
 status-dma-gpi: 6.13
 status-dma-gpi-comment: DT bits in 6.14

--- a/_soc/sar2130p.md
+++ b/_soc/sar2130p.md
@@ -85,7 +85,8 @@ status-remoteproc-cdsp-comment: crashes on startup
 status-remoteproc-fastrpc:
 status-remoteproc-mdsp: N/A
 status-remoteproc-sdsp: N/A
-status-smmu: 6.13
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.13
 status-smmu-comment: DT bits in 6.14
 status-spi: 6.14
 status-spmi: 6.13

--- a/_soc/sar2130p.md
+++ b/_soc/sar2130p.md
@@ -109,6 +109,7 @@ status-usb-typec:
 status-usb-usb4: N/A
 status-usb-usbotg:
 status-video-venus:
+status-video-vidc: N/A
 status-watchdog:
 pmic: pm8150
 ---

--- a/_soc/sc7180.md
+++ b/_soc/sc7180.md
@@ -50,6 +50,7 @@ status-uart: 5.6
 status-usb: 5.6
 status-usb-periphmode: 5.6
 status-video-venus: 5.7
+status-video-vidc: N/A
 status-watchdog: 5.6
 pmic: pm6150, pm6150l
 ---

--- a/_soc/sc7180.md
+++ b/_soc/sc7180.md
@@ -35,7 +35,8 @@ status-qfprom: 5.6
 status-remoteproc: 5.8
 status-remoteproc-adsp: 6.7
 status-remoteproc-mdsp: 5.8
-status-smmu: 5.6
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.6
 status-spi: 5.6
 status-spmi: 5.6
 status-sram-imem: 5.16

--- a/_soc/sc8180x.md
+++ b/_soc/sc8180x.md
@@ -69,7 +69,8 @@ status-remoteproc-cdsp: 6.5
 status-remoteproc-fastrpc: N/A
 status-remoteproc-mdsp: 6.5
 status-remoteproc-sdsp: N/A
-status-smmu: 6.5
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.5
 status-spi: 6.5
 status-spmi: 6.5
 status-sram-imem: N/A

--- a/_soc/sc8180x.md
+++ b/_soc/sc8180x.md
@@ -90,6 +90,7 @@ status-usb-typec: 6.6
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus: N/A
+status-video-vidc: N/A
 status-watchdog: N/A
 pmic: pm8150, pm8150l, smb2351
 ---

--- a/_soc/sc8180x.md
+++ b/_soc/sc8180x.md
@@ -48,6 +48,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N/A
 status-dma-gpi: N/A
 status-gnss: N/A

--- a/_soc/sc8280xp.md
+++ b/_soc/sc8280xp.md
@@ -45,7 +45,8 @@ status-interconnects: 6.0
 status-keypad: 6.0
 status-llcc: 6.0
 status-pcie: 6.0
-status-smmu: 6.0
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.0
 status-pinctrl: 6.0
 status-pmu-armpmu: 6.0
 status-pmu-bwmon: 6.2

--- a/_soc/sc8280xp.md
+++ b/_soc/sc8280xp.md
@@ -37,6 +37,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N/A
 status-dma-gpi: 6.18
 status-i2c: 6.0

--- a/_soc/sc8280xp.md
+++ b/_soc/sc8280xp.md
@@ -73,6 +73,7 @@ status-uart: 6.0
 status-usb-hostmode: 6.0
 status-usb-typec: 6.0
 status-usb-usbotg: 6.5
+status-video-vidc: N/A
 status-watchdog: 6.0
 pmic: pmk8280, pmc8280, pmc8280c, pmr735a
 ---

--- a/_soc/sdm845.md
+++ b/_soc/sdm845.md
@@ -64,6 +64,7 @@ status-usb: 4.20
 status-usb-hostmode: 4.20
 status-usb-periphmode: 4.20
 status-video-venus: 5.4
+status-video-vidc: N/A
 status-watchdog: 5.5
 pmic: pm8998, pmi8998, pm8005
 ---

--- a/_soc/sdm845.md
+++ b/_soc/sdm845.md
@@ -49,7 +49,8 @@ status-remoteproc-cdsp: 5.2
 status-remoteproc-fastrpc: 5.4
 status-remoteproc-mdsp: 5.3
 status-remoteproc-sdsp: WIP
-status-smmu: 5.1
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.1
 status-spi: 4.19
 status-spmi: 4.18
 status-sram-rpmh-stats: 6.1

--- a/_soc/sdx65.md
+++ b/_soc/sdx65.md
@@ -67,7 +67,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N/A
 status-remoteproc-mdsp: 6.0
 status-remoteproc-sdsp: N/A
-status-smmu: 5.19
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.19
 status-spi: N/A
 status-spmi: 5.19
 status-sram-imem: 6.0

--- a/_soc/sdx65.md
+++ b/_soc/sdx65.md
@@ -47,6 +47,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-kgsl: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 6.0
 status-dma-gpi: N/A
 status-gnss: N/A

--- a/_soc/sdx65.md
+++ b/_soc/sdx65.md
@@ -88,6 +88,7 @@ status-usb-typec: WIP
 status-usb-usb4:
 status-usb-usbotg:
 status-video-venus: N/A
+status-video-vidc: N/A
 status-watchdog: 6.0
 pmic: pmk8350, pm8150b, pmx65
 ---

--- a/_soc/sdx75.md
+++ b/_soc/sdx75.md
@@ -89,6 +89,7 @@ status-usb-typec: WIP
 status-usb-usb4: N/A
 status-usb-usbotg: WIP
 status-video-venus: N/A
+status-video-vidc: N/A
 status-watchdog: WIP
 pmic: pm7550ba, pmk8550, pmx75
 ---

--- a/_soc/sdx75.md
+++ b/_soc/sdx75.md
@@ -68,7 +68,8 @@ status-remoteproc-cdsp: N/A
 status-remoteproc-fastrpc: N/A
 status-remoteproc-mdsp: 6.12
 status-remoteproc-sdsp: N/A
-status-smmu: 6.5
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.5
 status-spi: 6.11
 status-spmi: 6.6
 status-sram-imem: WIP

--- a/_soc/sdx75.md
+++ b/_soc/sdx75.md
@@ -47,6 +47,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-kgsl: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: WIP
 status-dma-gpi: 6.11
 status-gnss: N/A

--- a/_soc/sm4450.md
+++ b/_soc/sm4450.md
@@ -48,6 +48,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: N
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: N
 status-dma-gpi: N
 status-gnss: N/A

--- a/_soc/sm4450.md
+++ b/_soc/sm4450.md
@@ -90,6 +90,7 @@ status-usb-typec:
 status-usb-usb4:
 status-usb-usbotg:
 status-video-venus: N/A
+status-video-vidc: N/A
 status-watchdog: N
 pmic: pm4450, pm4450c, pmg1110, pm8010, pm3001a
 ---

--- a/_soc/sm4450.md
+++ b/_soc/sm4450.md
@@ -69,7 +69,8 @@ status-remoteproc-cdsp: N
 status-remoteproc-fastrpc: N
 status-remoteproc-mdsp: N/A
 status-remoteproc-sdsp: N/A
-status-smmu: N
+status-mmu-iommu: N/A
+status-mmu-smmu: N
 status-spi: N
 status-spmi: N
 status-sram-imem: N

--- a/_soc/sm6350.md
+++ b/_soc/sm6350.md
@@ -49,6 +49,7 @@ status-display-hdmi: N/A
 status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam:
 status-dma-gpi: 6.1
 status-gnss:

--- a/_soc/sm6350.md
+++ b/_soc/sm6350.md
@@ -70,7 +70,8 @@ status-remoteproc-cdsp: 5.17
 status-remoteproc-fastrpc: 5.17
 status-remoteproc-mdsp: 5.17
 status-remoteproc-sdsp: N/A
-status-smmu: 5.16
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.16
 status-spi:
 status-spmi: 5.16
 status-sram-imem: WIP

--- a/_soc/sm6350.md
+++ b/_soc/sm6350.md
@@ -91,6 +91,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus:
+status-video-vidc: N/A
 status-watchdog: 5.16
 pmic: pm6150l, pm6350, pm7250b, pmk8350
 ---

--- a/_soc/sm8150.md
+++ b/_soc/sm8150.md
@@ -51,6 +51,7 @@ status-usb-periphmode: 5.9
 status-usb-typec: 6.8
 status-usb-usbotg: 6.8
 status-usb-usb4: N/A
+status-video-vidc: N/A
 status-watchdog: 5.6
 pmic: pm8150, pm8150b, pm8150l, pm8009
 ---

--- a/_soc/sm8150.md
+++ b/_soc/sm8150.md
@@ -34,7 +34,8 @@ status-remoteproc-cdsp: 5.6
 status-remoteproc-fastrpc: 5.16
 status-remoteproc-mdsp: 5.6
 status-remoteproc-sdsp: 5.6
-status-smmu: 5.11
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.11
 status-spi: 5.14
 status-spmi: 5.4
 status-sram-rpmh-stats: 5.16

--- a/_soc/sm8250.md
+++ b/_soc/sm8250.md
@@ -46,7 +46,8 @@ status-remoteproc-cdsp: 5.8
 status-remoteproc-fastrpc: 5.11
 status-remoteproc-mdsp: N/A
 status-remoteproc-sdsp: 5.9
-status-smmu: 5.11
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.11
 status-spi: 5.9
 status-spmi: 5.7
 status-sram-rpmh-stats: 5.16

--- a/_soc/sm8250.md
+++ b/_soc/sm8250.md
@@ -62,6 +62,7 @@ status-usb-periphmode: 5.11
 status-usb-typec: 6.7
 status-usb-usb4: N/A
 status-video-venus: 5.13
+status-video-vidc: N/A
 status-watchdog: 5.9
 pmic: pm8150, pm8150b, pm8150l, pm8009
 ---

--- a/_soc/sm8350.md
+++ b/_soc/sm8350.md
@@ -48,6 +48,7 @@ status-usb: 5.13
 status-usb-hostmode: 5.13
 status-usb-periphmode: 5.13
 status-usb-usb4: N/A
+status-video-vidc: N/A
 pmic: pm8350, pm8350b, pm8350c, pmk8350, pmr735a, pmr735b
 ---
 Tested Boards:

--- a/_soc/sm8350.md
+++ b/_soc/sm8350.md
@@ -35,7 +35,8 @@ status-remoteproc-cdsp: 5.13
 status-remoteproc-fastrpc: 5.16
 status-remoteproc-mdsp: 5.13
 status-remoteproc-sdsp: 5.13
-status-smmu: 5.13
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.13
 status-spi: 5.17
 status-spmi: 5.13
 status-storage-nand: N/A

--- a/_soc/sm8450.md
+++ b/_soc/sm8450.md
@@ -91,6 +91,7 @@ status-usb-typec: 6.4
 status-usb-usb4:
 status-usb-usbotg:
 status-video-venus: N
+status-video-vidc: N/A
 status-watchdog: N
 pmic: pm8350, pm8350b, pm8350c, pm8450, pmk8350, pmr735a, pmr735b
 ---

--- a/_soc/sm8450.md
+++ b/_soc/sm8450.md
@@ -69,7 +69,8 @@ status-remoteproc-cdsp: 5.18
 status-remoteproc-fastrpc: 5.19
 status-remoteproc-mdsp: 5.18
 status-remoteproc-sdsp: 5.18
-status-smmu: 5.17
+status-mmu-iommu: N/A
+status-mmu-smmu: 5.17
 status-spi: 5.19
 status-spmi: 6.3
 status-sram-imem: 6.4

--- a/_soc/sm8450.md
+++ b/_soc/sm8450.md
@@ -48,6 +48,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: 6.8
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: WIP
 status-dma-gpi: 5.17
 status-gnss:

--- a/_soc/sm8550.md
+++ b/_soc/sm8550.md
@@ -73,7 +73,8 @@ status-remoteproc-cdsp: 6.3
 status-remoteproc-fastrpc: 6.3
 status-remoteproc-mdsp: 6.3
 status-remoteproc-sdsp: 6.3
-status-smmu: 6.3
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.3
 status-spi: 6.3
 status-spmi: 6.3
 status-sram-imem:

--- a/_soc/sm8550.md
+++ b/_soc/sm8550.md
@@ -51,6 +51,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: 6.8
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 6.3
 status-dma-gpi: 6.3
 status-gnss:

--- a/_soc/sm8550.md
+++ b/_soc/sm8550.md
@@ -96,6 +96,7 @@ status-usb-typec: 6.6
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus: 6.15
+status-video-vidc: N/A
 status-video-venus-comment: DT bits in 6.16
 status-watchdog: WIP
 pmic: pm8550, pm8550b, pm8550ve, pm8550vs, pmk8550, pmr735d, pm8010

--- a/_soc/sm8650.md
+++ b/_soc/sm8650.md
@@ -90,6 +90,7 @@ status-usb-typec: 6.8
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus: 6.17
+status-video-vidc: N/A
 status-watchdog: WIP
 pmic: pm8550, pm8550b, pm8550ve, pm8550vs, pmk8550, pmr735d, pm8010
 ---

--- a/_soc/sm8650.md
+++ b/_soc/sm8650.md
@@ -69,7 +69,8 @@ status-remoteproc-cdsp: 6.8
 status-remoteproc-fastrpc: 6.8
 status-remoteproc-mdsp: 6.8
 status-remoteproc-sdsp: N/A
-status-smmu: 6.3
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.3
 status-spi: 6.3
 status-spmi: 6.3
 status-sram-imem:

--- a/_soc/sm8650.md
+++ b/_soc/sm8650.md
@@ -48,6 +48,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: 6.10
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 6.3
 status-dma-gpi: 6.3
 status-gnss:

--- a/_soc/sm8750.md
+++ b/_soc/sm8750.md
@@ -49,6 +49,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu:
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam:
 status-dma-gpi: 6.14
 status-gnss:

--- a/_soc/sm8750.md
+++ b/_soc/sm8750.md
@@ -70,7 +70,8 @@ status-remoteproc-cdsp: 6.16
 status-remoteproc-fastrpc: mailing list
 status-remoteproc-mdsp: 6.16
 status-remoteproc-sdsp: N/A
-status-smmu: 6.14
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.14
 status-spi: 6.14
 status-spmi: 6.14
 status-sram-imem:

--- a/_soc/sm8750.md
+++ b/_soc/sm8750.md
@@ -91,6 +91,7 @@ status-usb-typec: 6.19
 status-usb-usb4: N/A
 status-usb-usbotg: N/A
 status-video-venus: mailing list
+status-video-vidc: N/A
 status-watchdog: WIP
 pmic: pm8010, pm8550, pm8550ve, pmd8028, pmih0108, pmk8550, pmr735d
 ---

--- a/_soc/talos.md
+++ b/_soc/talos.md
@@ -90,6 +90,7 @@ status-usb-typec: N/A
 status-usb-usb4: N/A
 status-usb-usbotg: WIP
 status-video-venus: 6.18
+status-video-vidc: N/A
 status-watchdog: 6.14
 pmic: pm8150
 ---

--- a/_soc/talos.md
+++ b/_soc/talos.md
@@ -48,6 +48,7 @@ status-display-hdmiaudio: N/A
 status-display-hdmicec: N/A
 status-display-gpu: WIP
 status-display-lvds: N/A
+status-dma-adm: N/A
 status-dma-bam: 6.14
 status-dma-gpi: 6.14
 status-gnss: N/A

--- a/_soc/talos.md
+++ b/_soc/talos.md
@@ -69,7 +69,8 @@ status-remoteproc-cdsp: 6.17
 status-remoteproc-fastrpc: 6.18
 status-remoteproc-mdsp: N/A
 status-remoteproc-sdsp: N/A
-status-smmu: 6.14
+status-mmu-iommu: N/A
+status-mmu-smmu: 6.14
 status-spi: 6.14
 status-spmi: 6.14
 status-sram-imem: 6.17

--- a/soc.yaml
+++ b/soc.yaml
@@ -208,6 +208,9 @@ video:
     venus:
       name: Venus
       intop: True
+    vidc:
+      name: VIDC
+      intop: True
 watchdog:
   name: Watchdog
   intop: True

--- a/soc.yaml
+++ b/soc.yaml
@@ -33,9 +33,16 @@ spi:
 pcie:
   name: PCIe
   intop: True
-smmu:
-  name: SMMU
+mmu:
+  name: MMU
   intop: True
+  items:
+    smmu:
+      name: SMMU
+      intop: True
+    iommu:
+      name: IOMMU
+      intop: True
 storage:
   name: Storage
   intop: True

--- a/soc.yaml
+++ b/soc.yaml
@@ -225,6 +225,8 @@ dma:
       name: GPI
     bam:
       name: BAM
+    adm:
+      name: ADM
 qfprom:
   name: QFPROM
 powerthermal:


### PR DESCRIPTION
Adding support for the Snapdragon S3 SoC family (apq8060/msm8260/msm8660).

I have this SoC close to fully working now on 6.18, migrating to linux-next and will be doing submissions to the various mailing lists to get all this work mainlined.

Changes made:
- Added IOMMU under MMU and moved SMMU there too.
- Added ADM DMA under DMA as new DMA type.
- Added VIDC under video. S3 uses VIDC, not Venus. The architecture is completely different.
